### PR TITLE
Enable metal

### DIFF
--- a/Sources/whisper/ggml-metal.m
+++ b/Sources/whisper/ggml-metal.m
@@ -196,7 +196,7 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
     // load library
     {
         NSBundle * bundle = nil;
-#ifdef SWIFT_PACKAGE
+#ifdef SWIFTPM_MODULE_BUNDLE
         bundle = SWIFTPM_MODULE_BUNDLE;
 #else
         bundle = [NSBundle bundleForClass:[GGMLMetalClass class]];


### PR DESCRIPTION
This enables using metal by adding an additional target for ggml-metal and then optionally including it in the build.

I also changed `ifdef SWIFT_PACKAGE` to `ifdef SWIFTPM_MODULE_BUNDLE` since I had the former variable set and not the latter (not sure why).

This works on my machine, but I'm not a rapper, so please let me know if I made a mistake.